### PR TITLE
Fixed issue with bbmap gzip

### DIFF
--- a/genemethods/assemblypipeline/quality.py
+++ b/genemethods/assemblypipeline/quality.py
@@ -440,7 +440,7 @@ class Quality(object):
             out, err = run_subprocess(systemcall_r)
             write_to_logfile(systemcall_r, systemcall_r, self.logfile, None, None, None, None)
             write_to_logfile(out, err, self.logfile, None, None, None, None)
-            logging.info('Fixing BBMap gunzip issue complete!')
+        logging.info('Fixing BBMap gunzip issue complete!')
 
     def estimate_genome_size(self):
         """

--- a/genemethods/assemblypipeline/quality.py
+++ b/genemethods/assemblypipeline/quality.py
@@ -440,7 +440,7 @@ class Quality(object):
             out, err = run_subprocess(systemcall_r)
             write_to_logfile(systemcall_r, systemcall_r, self.logfile, None, None, None, None)
             write_to_logfile(out, err, self.logfile, None, None, None, None)
-            logging.info('Fizing BBMap gunzip issue complete!')
+            logging.info('Fixing BBMap gunzip issue complete!')
 
     def estimate_genome_size(self):
         """


### PR DESCRIPTION
While trying to run the pipeline, I ran into an issue where the gzip'ed files from BBMap were creating errors (Invalid fastq file format). 

Found a solution where unzipping and rezipping the file with gunzip would fix the formatting issue.